### PR TITLE
conf: set update-manifest configuration options

### DIFF
--- a/conf/update-manifest.conf
+++ b/conf/update-manifest.conf
@@ -1,0 +1,2 @@
+URL=https://github.com/arduino/lmp-manifest
+PREFIX=arduino


### PR DESCRIPTION
Arduino manages their own upstream version of lmp-manifest.  Setup configuration
so that update-manifest script points at the right git.

Signed-off-by: Michael Scott <mike@foundries.io>