### PR TITLE
[meta-partner-arduino] Enable checkout of git submodules during `repo sync`

### DIFF
--- a/arduino.xml
+++ b/arduino.xml
@@ -7,5 +7,6 @@
   <project name="meta-partner-arduino"
            revision="e3797ee3e0869d6d621da9a2fd898e823adc2db7"
            path="layers/meta-partner-arduino"
-           remote="partner-arduino"/>
+           remote="partner-arduino"
+           sync-s="true" />
 </manifest>


### PR DESCRIPTION
This is necessary due to x8h7 being now a git submodule (see https://github.com/arduino/meta-partner-arduino/pull/40 ).